### PR TITLE
11 telnet server simple challenge

### DIFF
--- a/Pwn/telnet_server_simple_challenge/Dockerfile
+++ b/Pwn/telnet_server_simple_challenge/Dockerfile
@@ -1,0 +1,19 @@
+FROM alpine:latest
+
+# telnet package is installed via busybox-extras
+RUN apk update && apk upgrade --available && apk add --upgrade busybox-extras
+
+# Create a group and user which can not get a "real" login though
+RUN addgroup -S appgroup && adduser -S admin -G appgroup -h /home/admin -s /sbin/nologin
+
+# change password; this user can then be logged in with via telnet
+RUN echo 'admin:admin' | chpasswd
+
+# configure telnet
+#RUN echo "telnet stream tcp nowait root /usr/sbin/telnetd telnetd -i -l /bin/login" > /etc/inetd.conf
+
+# we put our message in the message of the day file (this will be shown before /sbin/nologin is executed)
+RUN echo -e "\n\nHere you go:\n\n"'BTU{wh4t_1z_t3ln3t}'"\n\n" > /etc/motd
+
+# run telnetd in foreground, on tcp port 23
+ENTRYPOINT [ "telnetd", "-p", "23", "-F"]

--- a/Pwn/telnet_server_simple_challenge/Dockerfile
+++ b/Pwn/telnet_server_simple_challenge/Dockerfile
@@ -9,9 +9,6 @@ RUN addgroup -S appgroup && adduser -S admin -G appgroup -h /home/admin -s /sbin
 # change password; this user can then be logged in with via telnet
 RUN echo 'admin:admin' | chpasswd
 
-# configure telnet
-#RUN echo "telnet stream tcp nowait root /usr/sbin/telnetd telnetd -i -l /bin/login" > /etc/inetd.conf
-
 # we put our message in the message of the day file (this will be shown before /sbin/nologin is executed)
 RUN echo -e "\n\nHere you go:\n\n"'BTU{wh4t_1z_t3ln3t}'"\n\n" > /etc/motd
 

--- a/Pwn/telnet_server_simple_challenge/README.MD
+++ b/Pwn/telnet_server_simple_challenge/README.MD
@@ -1,0 +1,10 @@
+# Telnet Server Simple Challenge
+
+users can simply login with username "admin" and password "admin" to grab the flag via the motd file. they can e.g. bruteforce this login.
+they do not get a real shell, since the login shell of the user "admin" is `/sbin/nologin`
+the telnet server is running on tcp port 23. we could also set the port to sth else, to spice it up a little.
+
+## how to run it
+
+`docker build -t telnet_challenge . && docker run --rm -it --name telnet_challenge -p 127.0.0.1:23:23 telnet_challenge`
+


### PR DESCRIPTION
users can simply login with username "admin" and password "admin" to grab the flag via the motd file. 
they can e.g. bruteforce this login.
they do not get a real shell, since the login shell of the user "admin" is `/sbin/nologin`
the telnet server is running on tcp port 23. we could also set the port to sth else, to spice it up a little.